### PR TITLE
crashfix: RequestHandler: more generic exception catching to catch java.lang.AssertionError on executing the http request

### DIFF
--- a/AdjustIo/src/com/adeven/adjustio/RequestHandler.java
+++ b/AdjustIo/src/com/adeven/adjustio/RequestHandler.java
@@ -117,8 +117,8 @@ public class RequestHandler extends HandlerThread {
             closePackage(activityPackage, "Request timed out", e);
         } catch (IOException e) {
             closePackage(activityPackage, "Request failed", e);
-        } catch (Exception e) {
-            sendNextPackage(activityPackage, "Runtime exeption", e);
+        } catch (Throwable e) {
+            sendNextPackage(activityPackage, "Runtime exception", e);
         }
     }
 


### PR DESCRIPTION
AssertionError is thrown on some devices where for example MD5 is not available: java.security.NoSuchAlgorithmException: MessageDigest MD5 implementation not found

[stacktrace](https://gist.github.com/wellle/8053854)

---

[edit by @wellle: moved stacktrace into gist]
