### PR TITLE
package sending was decoupled and moved to ActivityHandler

### DIFF
--- a/Adjust/src/com/adjust/sdk/PackageHandler.java
+++ b/Adjust/src/com/adjust/sdk/PackageHandler.java
@@ -62,7 +62,7 @@ public class PackageHandler extends HandlerThread implements IPackageHandler {
         internalHandler.sendMessage(message);
     }
 
-    // add a package to the queue, trigger sending
+    // add a package to the queue
     @Override
     public void addPackage(ActivityPackage pack) {
         Message message = Message.obtain();


### PR DESCRIPTION
Looks like this was migrated out when buffering of packages was implemented.
