### PR TITLE
changed task directory in build.gradle

### DIFF
--- a/Adjust/build.gradle
+++ b/Adjust/build.gradle
@@ -40,7 +40,7 @@ android {
 }
 
 task jar(type: Jar) {
-  from android.sourceSets.main.java
+  from 'src/main/java'
 }
 
 task wrapper(type: Wrapper) {


### PR DESCRIPTION
my project wouldn't build with:
```groovy
    from android.sourceSets.main.java
```
this SO [post] (http://stackoverflow.com/questions/26787490/gradle-2-1-error-cannot-convert-the-provided-notation-to-a-file-or-uri-src-main) led me toward a solution. 

possible all due to me using the latest gradle version 2.2.1