### PR TITLE
Added clickLabel param to AdjustAttribution

### DIFF
--- a/Adjust/adjust/src/main/java/com/adjust/sdk/AdjustAttribution.java
+++ b/Adjust/adjust/src/main/java/com/adjust/sdk/AdjustAttribution.java
@@ -20,7 +20,8 @@ public class AdjustAttribution implements Serializable {
             new ObjectStreamField("network", String.class),
             new ObjectStreamField("campaign", String.class),
             new ObjectStreamField("adgroup", String.class),
-            new ObjectStreamField("creative", String.class)
+            new ObjectStreamField("creative", String.class),
+            new ObjectStreamField("clickLabel", String.class)
     };
 
     public String trackerToken;
@@ -29,6 +30,7 @@ public class AdjustAttribution implements Serializable {
     public String campaign;
     public String adgroup;
     public String creative;
+    public String clickLabel;
 
     public static AdjustAttribution fromJson(JSONObject jsonObject) {
         if (jsonObject == null) return null;
@@ -41,6 +43,7 @@ public class AdjustAttribution implements Serializable {
         attribution.campaign = jsonObject.optString("campaign", null);
         attribution.adgroup = jsonObject.optString("adgroup", null);
         attribution.creative = jsonObject.optString("creative", null);
+        attribution.clickLabel = jsonObject.optString("click_label", null);
 
         return attribution;
     }
@@ -58,6 +61,7 @@ public class AdjustAttribution implements Serializable {
         if (!Util.equalString(campaign, otherAttribution.campaign)) return false;
         if (!Util.equalString(adgroup, otherAttribution.adgroup)) return false;
         if (!Util.equalString(creative, otherAttribution.creative)) return false;
+        if (!Util.equalString(clickLabel, otherAttribution.clickLabel)) return false;
         return true;
     }
 
@@ -70,14 +74,15 @@ public class AdjustAttribution implements Serializable {
         hashCode = 37 * hashCode + Util.hashString(campaign);
         hashCode = 37 * hashCode + Util.hashString(adgroup);
         hashCode = 37 * hashCode + Util.hashString(creative);
+        hashCode = 37 * hashCode + Util.hashString(clickLabel);
         return hashCode;
     }
 
 
     @Override
     public String toString() {
-        return String.format(Locale.US, "tt:%s tn:%s net:%s cam:%s adg:%s cre:%s",
-                trackerToken, trackerName, network, campaign, adgroup, creative);
+        return String.format(Locale.US, "tt:%s tn:%s net:%s cam:%s adg:%s cre:%s cl:%s",
+                trackerToken, trackerName, network, campaign, adgroup, creative, clickLabel);
     }
 
     private void writeObject(ObjectOutputStream stream) throws IOException {

--- a/Adjust/test/src/androidTest/java/com/adjust/sdk/test/MockHttpClient.java
+++ b/Adjust/test/src/androidTest/java/com/adjust/sdk/test/MockHttpClient.java
@@ -62,7 +62,8 @@ public class MockHttpClient implements HttpClient {
                             "\"network\"       : \"nValue\" , " +
                             "\"campaign\"      : \"cpValue\" , " +
                             "\"adgroup\"       : \"aValue\" , " +
-                            "\"creative\"      : \"ctValue\" } }");
+                            "\"creative\"      : \"ctValue\" , " +
+                            "\"click_label\"   : \"clValue\" } }");
         } else if (responseType == ResponseType.ASK_IN) {
             return getOkResponse("{ \"ask_in\" : 4000 }");
         }

--- a/Adjust/test/src/androidTest/java/com/adjust/sdk/test/TestActivityHandler.java
+++ b/Adjust/test/src/androidTest/java/com/adjust/sdk/test/TestActivityHandler.java
@@ -988,7 +988,7 @@ public class TestActivityHandler extends ActivityInstrumentationTestCase2<UnitTe
 
         // check that updates attribution
         assertUtil.isTrue(firstActivityHandler.tryUpdateAttribution(emptyAttribution));
-        assertUtil.debug("Wrote Attribution: tt:null tn:null net:null cam:null adg:null cre:null");
+        assertUtil.debug("Wrote Attribution: tt:null tn:null net:null cam:null adg:null cre:null cl:null");
 
         emptyAttribution = AdjustAttribution.fromJson(emptyJsonResponse);
 
@@ -1033,7 +1033,8 @@ public class TestActivityHandler extends ActivityInstrumentationTestCase2<UnitTe
                     "\"network\"       : \"nValue\" , " +
                     "\"campaign\"      : \"cpValue\" , " +
                     "\"adgroup\"       : \"aValue\" , " +
-                    "\"creative\"      : \"ctValue\" }");
+                    "\"creative\"      : \"ctValue\" , " +
+                    "\"click_label\"   : \"clValue\" }");
         } catch (JSONException e) {
             fail(e.getMessage());
         }
@@ -1041,12 +1042,12 @@ public class TestActivityHandler extends ActivityInstrumentationTestCase2<UnitTe
 
         //check that it updates
         assertUtil.isTrue(restartActivityHandler.tryUpdateAttribution(firstAttribution));
-        assertUtil.debug("Wrote Attribution: tt:ttValue tn:tnValue net:nValue cam:cpValue adg:aValue cre:ctValue");
+        assertUtil.debug("Wrote Attribution: tt:ttValue tn:tnValue net:nValue cam:cpValue adg:aValue cre:ctValue cl:clValue");
 
         // check that it launch the saved attribute
         SystemClock.sleep(1000);
 
-        assertUtil.test("onAttributionChanged: tt:ttValue tn:tnValue net:nValue cam:cpValue adg:aValue cre:ctValue");
+        assertUtil.test("onAttributionChanged: tt:ttValue tn:tnValue net:nValue cam:cpValue adg:aValue cre:ctValue cl:clValue");
 
         // check that it does not update the attribution
         assertUtil.isFalse(restartActivityHandler.tryUpdateAttribution(firstAttribution));
@@ -1089,7 +1090,8 @@ public class TestActivityHandler extends ActivityInstrumentationTestCase2<UnitTe
                     "\"network\"       : \"nValue2\" , " +
                     "\"campaign\"      : \"cpValue2\" , " +
                     "\"adgroup\"       : \"aValue2\" , " +
-                    "\"creative\"      : \"ctValue2\" }");
+                    "\"creative\"      : \"ctValue2\" , " +
+                    "\"click_label\"   : \"clValue2\" }");
         } catch (JSONException e) {
             fail(e.getMessage());
         }
@@ -1097,12 +1099,12 @@ public class TestActivityHandler extends ActivityInstrumentationTestCase2<UnitTe
 
         //check that it updates
         assertUtil.isTrue(secondRestartActivityHandler.tryUpdateAttribution(secondAttribution));
-        assertUtil.debug("Wrote Attribution: tt:ttValue2 tn:tnValue2 net:nValue2 cam:cpValue2 adg:aValue2 cre:ctValue2");
+        assertUtil.debug("Wrote Attribution: tt:ttValue2 tn:tnValue2 net:nValue2 cam:cpValue2 adg:aValue2 cre:ctValue2 cl:clValue2");
 
         // check that it launch the saved attribute
         SystemClock.sleep(1000);
 
-        assertUtil.test("onAttributionChanged: tt:ttValue2 tn:tnValue2 net:nValue2 cam:cpValue2 adg:aValue2 cre:ctValue2");
+        assertUtil.test("onAttributionChanged: tt:ttValue2 tn:tnValue2 net:nValue2 cam:cpValue2 adg:aValue2 cre:ctValue2 cl:clValue2");
 
         // check that it does not update the attribution
         assertUtil.isFalse(secondRestartActivityHandler.tryUpdateAttribution(secondAttribution));
@@ -1433,7 +1435,8 @@ public class TestActivityHandler extends ActivityInstrumentationTestCase2<UnitTe
                     "\"network\"       : \"nValue\" , " +
                     "\"campaign\"      : \"cpValue\" , " +
                     "\"adgroup\"       : \"aValue\" , " +
-                    "\"creative\"      : \"ctValue\" }");
+                    "\"creative\"      : \"ctValue\" , " +
+                    "\"click_label\"   : \"clValue\" }");
         } catch (JSONException e) {
             fail(e.getMessage());
         }
@@ -1443,7 +1446,7 @@ public class TestActivityHandler extends ActivityInstrumentationTestCase2<UnitTe
         activityHandler.tryUpdateAttribution(attribution);
 
         // attribution was updated
-        assertUtil.debug("Wrote Attribution: tt:ttValue tn:tnValue net:nValue cam:cpValue adg:aValue cre:ctValue");
+        assertUtil.debug("Wrote Attribution: tt:ttValue tn:tnValue net:nValue cam:cpValue adg:aValue cre:ctValue cl:clValue");
 
         // trigger a new sub session
         activityHandler.trackSubsessionStart();

--- a/Adjust/test/src/androidTest/java/com/adjust/sdk/test/TestAttributionHandler.java
+++ b/Adjust/test/src/androidTest/java/com/adjust/sdk/test/TestAttributionHandler.java
@@ -323,14 +323,15 @@ public class TestAttributionHandler extends ActivityInstrumentationTestCase2<Uni
                 "\"network\"       : \"nValue\" , " +
                 "\"campaign\"      : \"cpValue\" , " +
                 "\"adgroup\"       : \"aValue\" , " +
-                "\"creative\"      : \"ctValue\" } }";
+                "\"creative\"      : \"ctValue\" , " +
+                "\"click_label\"   : \"clValue\" } }";
 
         mockActivityHandler.updated = updated;
 
         callCheckAttributionWithGet(attributionHandler, ResponseType.ATTRIBUTION, response);
 
         // check attribution was called without ask_in
-        assertUtil.test("ActivityHandler tryUpdateAttribution, tt:ttValue tn:tnValue net:nValue cam:cpValue adg:aValue cre:ctValue");
+        assertUtil.test("ActivityHandler tryUpdateAttribution, tt:ttValue tn:tnValue net:nValue cam:cpValue adg:aValue cre:ctValue cl:clValue");
 
         // updated set askingAttribution to false
         assertUtil.test("ActivityHandler setAskingAttribution, false");

--- a/Adjust/test/src/androidTest/java/com/adjust/sdk/test/TestRequestHandler.java
+++ b/Adjust/test/src/androidTest/java/com/adjust/sdk/test/TestRequestHandler.java
@@ -202,12 +202,12 @@ public class TestRequestHandler extends ActivityInstrumentationTestCase2<UnitTes
 
         assertUtil.test("HttpClient execute, responseType: ATTRIBUTION");
 
-        assertUtil.verbose("Response: { \"attribution\" : {\"tracker_token\" : \"ttValue\" , \"tracker_name\"  : \"tnValue\" , \"network\"       : \"nValue\" , \"campaign\"      : \"cpValue\" , \"adgroup\"       : \"aValue\" , \"creative\"      : \"ctValue\" } }");
+        assertUtil.verbose("Response: { \"attribution\" : {\"tracker_token\" : \"ttValue\" , \"tracker_name\"  : \"tnValue\" , \"network\"       : \"nValue\" , \"campaign\"      : \"cpValue\" , \"adgroup\"       : \"aValue\" , \"creative\"      : \"ctValue\" , \"click_label\"   : \"clValue\" } }");
 
         assertUtil.info("No message found");
 
         JsonParser parser = new JsonParser();
-        JsonElement e1 = parser.parse("{\"attribution\":{\"tracker_token\":\"ttValue\",\"tracker_name\":\"tnValue\",\"network\":\"nValue\",\"campaign\":\"cpValue\",\"adgroup\":\"aValue\",\"creative\":\"ctValue\"}}");
+        JsonElement e1 = parser.parse("{\"attribution\":{\"tracker_token\":\"ttValue\",\"tracker_name\":\"tnValue\",\"network\":\"nValue\",\"campaign\":\"cpValue\",\"adgroup\":\"aValue\",\"creative\":\"ctValue\",\"click_label\":\"clValue\"}}");
         JsonElement e2 = parser.parse(mockPackageHandler.jsonResponse.toString());
 
         assertEquals(e1, e2);


### PR DESCRIPTION
Here's a little code to expose the `click_label` field via the AdjustAttribution class. I also updated the `AdjustAttribution.toString()` output and all relevant unit tests.

Regarding the unit tests, I'm seeing failures in TestActivityHandler, specifically:
* `testChecks` sometimes fails
* `testEventsBuffered` always fails
* `testOfflineMode` sometimes fails

However I get the same results with or without my changes, so I suspect these might be known issues?

Thanks!
Mike