### PR TITLE
Fixing logger Assert message when notifying about environment.

### DIFF
--- a/Adjust/adjust/src/main/java/com/adjust/sdk/AdjustConfig.java
+++ b/Adjust/adjust/src/main/java/com/adjust/sdk/AdjustConfig.java
@@ -164,13 +164,13 @@ public class AdjustConfig {
         }
 
         if (environment.equals(AdjustConfig.ENVIRONMENT_SANDBOX)) {
-            logger.Assert("SANDBOX: Adjust is running in Sandbox mode. " +
+            logger.warn("SANDBOX: Adjust is running in Sandbox mode. " +
                     "Use this setting for testing. " +
                     "Don't forget to set the environment to `production` before publishing!");
             return true;
         }
         if (environment.equals(AdjustConfig.ENVIRONMENT_PRODUCTION)) {
-            logger.Assert(
+            logger.warn(
                     "PRODUCTION: Adjust is running in Production mode. " +
                             "Use this setting only for the build that you want to publish. " +
                             "Set the environment to `sandbox` if you want to test your app!");


### PR DESCRIPTION
The Adjust SDK seems to use ASSERT for things that are definitely not fatal errors. This message for instance: "Adjust is running in Production mode. Use this setting only for the build that you want to publish. Set the environment to `sandbox` if you want to test your app!"

This leads to some weird stuff in our Google Play Console. See below, this is a crash in our NDK native code. And I know that Adjust has nothing to do with this crash. But it seems that the Android system is using the last ASSERT log message as an "Abort message" here.

Assert should only be used if there's something that absolutely shouldn't happen and probably isn't recoverable from.

`*** *** *** *** *** *** *** *** *** *** *** *** *** *** *** ***
Build fingerprint: 'motorola/osprey_retla_ds/osprey_uds:6.0/MPI24.65-33.1/1:user/release-keys'
Revision: 'p2b0'
ABI: 'arm'
pid: 31113, tid: 31129, name: AsyncTask #1  >>> com.... <<<
signal 11 (SIGSEGV), code 1 (SEGV_MAPERR), fault addr 0x10
Abort message: 'PRODUCTION: Adjust is running in Production mode. Use this setting only for the build that you want to publish. Set the environment to 'sandbox' if you want to test your app!'
    r0 00000000  r1 00000000  r2 00000000  r3 00000000
    r4 b89c7fa8  r5 00000002  r6 b89c7fac  r7 a21092a8
    r8 b89c7fbc  r9 00000002  sl a210936c  fp 00000000
    ip a273ede4  sp a2109000  lr a22dc05d  pc a233a578  cpsr 400f0010
`
