### PR TITLE
AdjustReferrerReceiver: update link to Appington blog post

### DIFF
--- a/Adjust/adjust/src/main/java/com/adjust/sdk/AdjustReferrerReceiver.java
+++ b/Adjust/adjust/src/main/java/com/adjust/sdk/AdjustReferrerReceiver.java
@@ -12,7 +12,7 @@ import static com.adjust.sdk.Constants.MALFORMED;
 import static com.adjust.sdk.Constants.REFERRER;
 
 // support multiple BroadcastReceivers for the INSTALL_REFERRER:
-// http://blog.appington.com/2012/08/01/giving-credit-for-android-app-installs
+// https://appington.wordpress.com/2012/08/01/giving-credit-for-android-app-installs/
 
 public class AdjustReferrerReceiver extends BroadcastReceiver {
     @Override


### PR DESCRIPTION
For whatever reason the linked blog post is not available in that URL.

Updated for the link to work