### PR TITLE
Issue 327: Fix typos in Proguard rules & README

### DIFF
--- a/Adjust/adjust/adjust-proguard-rules.txt
+++ b/Adjust/adjust/adjust-proguard-rules.txt
@@ -17,10 +17,10 @@
     java.lang.String CPU_ABI;
 }
 -keep class android.content.res.Configuration {
-    android.os.LocaledList getLocales();
+    android.os.LocaleList getLocales();
     java.util.Locale locale;
 }
--keep class android.os.LocaledList {
+-keep class android.os.LocaleList {
     java.util.Locale get(int);
 }
 -keep public class com.android.installreferrer.** { *; }

--- a/Adjust/example/proguard-rules.pro
+++ b/Adjust/example/proguard-rules.pro
@@ -32,9 +32,9 @@
     java.lang.String CPU_ABI;
 }
 -keep class android.content.res.Configuration {
-    android.os.LocaledList getLocales();
+    android.os.LocaleList getLocales();
     java.util.Locale locale;
 }
--keep class android.os.LocaledList {
+-keep class android.os.LocaleList {
     java.util.Locale get(int);
 }

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ If you are using Proguard, add these lines to your Proguard file:
     android.os.LocaleList getLocales();
     java.util.Locale locale;
 }
--keep class android.os.LocaledList {
+-keep class android.os.LocaleList {
     java.util.Locale get(int);
 }
 -keep public class com.android.installreferrer.** { *; }


### PR DESCRIPTION
Further to #300, there are other examples of the typo in the README and
other proguard configuration files within the library and sample app.

Resolves #327 (not #307 as incorrectly quoted in commit message)