### PR TITLE
Update MIT-LICENSE

### DIFF
--- a/MIT-LICENSE
+++ b/MIT-LICENSE
@@ -1,5 +1,5 @@
 Copyright (c) 2012-2017 adjust GmbH,
-http://www.adjust.com
+https://www.adjust.com
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the


### PR DESCRIPTION
It's not a bug.

I think "https" is more suitable than "http" for the URL of the license file, so could you change it?
I thought it would be better to change to "https" for other places and other repositories.

I just wanted to make a suggestion, so you can close this pull request.
Thank you.