### PR TITLE
Allow attribution to be converted to Map

### DIFF
--- a/Adjust/sdk-core/src/main/java/com/adjust/sdk/AdjustAttribution.java
+++ b/Adjust/sdk-core/src/main/java/com/adjust/sdk/AdjustAttribution.java
@@ -7,6 +7,8 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.ObjectStreamField;
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Created by pfms on 07/11/14.
@@ -95,6 +97,23 @@ public class AdjustAttribution implements Serializable {
         if (!Util.equalString(costCurrency, otherAttribution.costCurrency)) return false;
 
         return true;
+    }
+
+    public Map<String, String> toMap() {
+        Map<String, String> fields = new HashMap<>();
+        if (trackerToken != null) fields.put("trackerToken", trackerToken);
+        if (trackerName != null) fields.put("trackerName", trackerName);
+        if (network != null) fields.put("network", network);
+        if (campaign != null) fields.put("campaign", campaign);
+        if (adgroup != null) fields.put("adgroup", adgroup);
+        if (creative != null) fields.put("creative", creative);
+        if (clickLabel != null) fields.put("clickLabel", clickLabel);
+        if (adid != null) fields.put("adid", adid);
+        if (costType != null) fields.put("costType", costType);
+        if (costAmount != null) fields.put("costAmount", costAmount.toString());
+        if (costCurrency != null) fields.put("costCurrency", costCurrency);
+
+        return fields;
     }
 
     @Override

--- a/Adjust/test-app-core/src/main/java/com/adjust/testapp/AdjustCommandExecutor.java
+++ b/Adjust/test-app-core/src/main/java/com/adjust/testapp/AdjustCommandExecutor.java
@@ -339,19 +339,7 @@ public class AdjustCommandExecutor {
                 public void onAttributionChanged(AdjustAttribution attribution) {
                     Log.d("TestApp", "attribution = " + attribution.toString());
 
-                    MainActivity.testLibrary.addInfoToSend("trackerToken", attribution.trackerToken);
-                    MainActivity.testLibrary.addInfoToSend("trackerName", attribution.trackerName);
-                    MainActivity.testLibrary.addInfoToSend("network", attribution.network);
-                    MainActivity.testLibrary.addInfoToSend("campaign", attribution.campaign);
-                    MainActivity.testLibrary.addInfoToSend("adgroup", attribution.adgroup);
-                    MainActivity.testLibrary.addInfoToSend("creative", attribution.creative);
-                    MainActivity.testLibrary.addInfoToSend("clickLabel", attribution.clickLabel);
-                    MainActivity.testLibrary.addInfoToSend("adid", attribution.adid);
-                    MainActivity.testLibrary.addInfoToSend("costType", attribution.costType);
-                    if (attribution.costAmount != null) {
-                        MainActivity.testLibrary.addInfoToSend("costAmount", attribution.costAmount.toString());
-                    }
-                    MainActivity.testLibrary.addInfoToSend("costCurrency", attribution.costCurrency);
+                    MainActivity.testLibrary.setInfoToSend(attribution.toMap());
                     MainActivity.testLibrary.sendInfoToServer(localBasePath);
                 }
             });

--- a/Adjust/test-library/src/main/java/com/adjust/test/TestLibrary.java
+++ b/Adjust/test-library/src/main/java/com/adjust/test/TestLibrary.java
@@ -154,6 +154,10 @@ public class TestLibrary {
         infoToServer.put(key, value);
     }
 
+    public void setInfoToSend(Map<String, String> info) {
+        infoToServer = info;
+    }
+
     public void sendInfoToServer(final String basePath) {
         executor.submit(new Runnable() {
             @Override


### PR DESCRIPTION
I would like to get the fields of AdjustAttribution in a map like ios_sdk.

https://github.com/adjust/ios_sdk/blob/b1feb897c1d40741ab97b304d90d8817160c57f5/Adjust/ADJAttribution.m#L87-L125

When tracking all the fields, it's hard to check if the fields are added every time this sdk is updated.